### PR TITLE
Don't pass NULL to memcmp when using sv_eq on SV_NULL

### DIFF
--- a/sv.h
+++ b/sv.h
@@ -249,8 +249,12 @@ SVDEF bool sv_eq(String_View a, String_View b)
 {
     if (a.count != b.count) {
         return false;
-    } else {
+    } else if (a.data && b.data) {
         return memcmp(a.data, b.data, a.count) == 0;
+    } else if (a.count == 0) {
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/test.c
+++ b/test.c
@@ -211,6 +211,33 @@ int main(void)
         }
     }
 
+    // Equals
+    {
+        // empty and null
+        {
+            String_View input = SV_STATIC("");
+            ASSERT_TRUE(sv_eq(input, SV_NULL));
+        }
+
+        // non-empty and null
+        {
+            String_View input = SV_STATIC("hello, world");
+            ASSERT_TRUE(!(sv_eq(input, SV_NULL)));
+        }
+
+        // equal
+        {
+            String_View input = SV_STATIC("hello, world");
+            ASSERT_TRUE(sv_eq(input, SV("hello, world")));
+        }
+
+        // unequal
+        {
+            String_View input = SV_STATIC("hello, world");
+            ASSERT_TRUE(!(sv_eq(input, SV("goodbye, world"))));
+        }
+    }
+
     // Equals, ignoring case
     {
         // exactly equal


### PR DESCRIPTION
Since doing so is undefined behavior, we probably want to avoid it.

Also added some tests to ensure things work as expected.